### PR TITLE
CVE-2025-61729: resolve CVE without requiring 0.16->0.17 or 0.16->1.x migrations

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,6 +1,6 @@
 # This version of Dockerfile is for building without external dependencies.
 # Build a multi-platform image e.g. `docker buildx build --push --platform linux/arm64,linux/amd64 --tag external-secrets:dev --file Dockerfile.standalone .`
-FROM golang:1.24.2-alpine@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee AS builder
+FROM golang:1.24.11-alpine@sha256:ef75fa8822a4c0fb53a390548b3dc1c39639339ec3373c58f5441117e1ff46ae AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ENV CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH}

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ helm.schema.plugin:
 
 helm.schema.update: helm.schema.plugin
 	@$(INFO) Generating values.schema.json
-	@helm schema -input $(HELM_DIR)/values.yaml -output $(HELM_DIR)/values.schema.json
+	@helm schema -f $(HELM_DIR)/values.yaml -o $(HELM_DIR)/values.schema.json
 	@$(OK) Generated values.schema.json
 
 helm.generate:

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-bookworm@sha256:79390b5e5af9ee6e7b1173ee3eac7fadf6751a545297672916b59bfa0ecf6f71 AS builder
+FROM golang:1.24.11-bookworm@sha256:328a50f29619c1a805851b8e0606ce94637d65c1b239d2fdccdbc3662c4d7313 AS builder
 
 ENV KUBECTL_VERSION="v1.28.3"
 ENV HELM_VERSION="v3.13.1"

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets-e2e
 
-go 1.24.2
+go 1.24.11
 
 replace (
 	github.com/Masterminds/sprig/v3 => github.com/external-secrets/sprig/v3 v3.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/external-secrets/external-secrets
 
-go 1.24.2
+go 1.24.11
 
 replace github.com/Masterminds/sprig/v3 => github.com/external-secrets/sprig/v3 v3.3.0
 

--- a/tilt.debug.dockerfile
+++ b/tilt.debug.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
+FROM golang:1.24.11@sha256:a61b432ba08dc45cc81d572932fa4cc3a8e3cb2321282f73891db455e735b507
 WORKDIR /
 COPY ./bin/external-secrets /external-secrets
 


### PR DESCRIPTION
# PR: fix: bump Go to 1.24.11 to address CVE-2025-61729

## Problem Statement

CVE-2025-61729 affects Go versions prior to 1.24.11 (and 1.25.0-1.25.4). The vulnerability exists in the `crypto/x509` package where `HostnameError.Error()` constructs error strings without limiting the number of hosts printed. This leads to excessive resource consumption due to repeated string concatenation with quadratic runtime complexity. A malicious certificate could exploit this to cause a denial-of-service condition.

Organizations using external-secrets v0.16.x are exposed to this vulnerability when the operator processes certificates from external secret providers.

## Related Issue

Community concerns around the current upgrade paths for the CVE: https://github.com/external-secrets/external-secrets/issues/4785

Fixes CVE-2025-61729

- **NVD:** https://nvd.nist.gov/vuln/detail/CVE-2025-61729
- **Go Advisory:** https://pkg.go.dev/vuln/GO-2025-4155
- **Go Issue:** https://go.dev/issue/76445

## Proposed Changes

This PR bumps Go from 1.24.2 to 1.24.11 across all relevant files:

| File | Change |
|------|--------|
| `go.mod` | `go 1.24.2` → `go 1.24.11` |
| `e2e/go.mod` | `go 1.24.2` → `go 1.24.11` |
| `Dockerfile.standalone` | `golang:1.24.2-alpine` → `golang:1.24.11-alpine` |
| `e2e/Dockerfile` | `golang:1.24.2-bookworm` → `golang:1.24.11-bookworm` |
| `tilt.debug.dockerfile` | `golang:1.24.2` → `golang:1.24.11` |

### Why patch v0.16.x instead of upgrading to v0.17.x or v1.x?

The v0.16 to v0.17 transition introduces breaking changes to existing APIVersions that would cause issues for organizations still relying on the v0.16 API contract. This security patch allows those organizations to address CVE-2025-61729 without being forced into a potentially disruptive API migration.

### Verification

- ✅ `go mod tidy` completes successfully
- ✅ Binary builds successfully (`make build-amd64`)
- ✅ Docker image builds successfully (`docker build -f Dockerfile.standalone`)
- ✅ Built container runs correctly

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`

